### PR TITLE
Fix for button tag and password input

### DIFF
--- a/lib/safariwatir.rb
+++ b/lib/safariwatir.rb
@@ -562,6 +562,7 @@ module Watir
     end
 
     class Password < TextField
+      def input_type; "password"; end
     end
 
     class Ol < ContentElement

--- a/lib/safariwatir.rb
+++ b/lib/safariwatir.rb
@@ -275,6 +275,7 @@ module Watir
     end
     
     class Button < InputElement
+      def tag; ["INPUT", "BUTTON"]; end
       include ButtonLocators
     end
         


### PR DESCRIPTION
I just added a two quick commits to allow the use of button tags (which I prefer to input type=submit) and the password field finder wasn't working for me (I think it was just looking for all input type=text's).
